### PR TITLE
Various fixes

### DIFF
--- a/public/app/js/Controllers/AppController.js
+++ b/public/app/js/Controllers/AppController.js
@@ -3,6 +3,7 @@ angular.module('semver').controller('AppController', function ($scope, $http, $l
 	var query = $location.search();
 
 	$scope.package = query.package || 'madewithlove/elasticsearcher';
+	$scope.previousPackage = $scope.package;
 	$scope.defaultVersion = '~1.2.3';
 	$scope.version = query.version || '^0.1.1';
 	$scope.stability = query['minimum-stability'] || 'stable';
@@ -22,7 +23,13 @@ angular.module('semver').controller('AppController', function ($scope, $http, $l
 	$scope.fetchVersions = function () {
 		$http.get('/packages/' + $scope.package).success(function (response) {
 			$scope.versions = response.versions;
-			$scope.version = $scope.defaultVersion = response.default_constraint;
+			$scope.defaultVersion = response.default_constraint;
+
+			if (!$scope.version || $scope.previousPackage !== $scope.package) {
+				$scope.version = response.default_constraint;
+			}
+
+			$scope.previousPackage = $scope.package;
 			$scope.errors.versions = false;
 
 			$scope.fetchMatchingVersions();

--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -25,6 +25,6 @@
         </ul>
 
         <h2>Satisfied?</h2>
-        <pre>composer require {{ package }}:{{ version }}</pre>
+        <pre>composer require {{ package }}:{{ version.indexOf('&') || version.indexOf('|') ? '"'+ version + '"': version }}</pre>
     </section>
 <?php $this->stop() ?>


### PR DESCRIPTION
### Fixed

* Don't replace version constraint with default when initial page load or when package name has not been changed
* Surround version constraint in `$ composer require` cli hint with quotes when it contains these special chars `&|`