### PR TITLE
Just surround version with quotes, much easier

### DIFF
--- a/resources/views/index.php
+++ b/resources/views/index.php
@@ -25,6 +25,6 @@
         </ul>
 
         <h2>Satisfied?</h2>
-        <pre>composer require {{ package }}:{{ version.indexOf('&') || version.indexOf('|') ? '"'+ version + '"': version }}</pre>
+        <pre>composer require {{ package }}:"{{ version }}"</pre>
     </section>
 <?php $this->stop() ?>


### PR DESCRIPTION
### Changed

* Just quote every version string for copying to terminal.

--
Because spaces and all kinds of chars can force you to surround it with quotes.