### PR TITLE
added canonical link

### DIFF
--- a/resources/views/_layout/global.php
+++ b/resources/views/_layout/global.php
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="canonical" href="http://semver.mwl.be">
     <title>Packagist Semver Checker - madewithlove</title>
     <meta name="description" content="Semver version constraint checker for packagist.">
     <link href='http://fonts.googleapis.com/css?family=Lato:300,400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
### Added

* canonical link in html header. Because (buzzword alert), SEO.

--
Because semver.madewithlove.be is also pointed towards this site now as well.