### PR TITLE
Fixed bug where 2.0.0 was higher than v2.8.0

### DIFF
--- a/app/Semver/Services/Packagist/Packagist.php
+++ b/app/Semver/Services/Packagist/Packagist.php
@@ -128,7 +128,12 @@ class Packagist
         $highestStability = $this->parser->parseStability($highestVersion);
 
         foreach ($versions as $version) {
-            if ($this->isMoreStable($version, $highestStability) || version_compare($highestVersion, $version, '<')) {
+            $nomalizedVersion = $this->parser->normalize($version);
+            $nomalizedHighestVersion = $this->parser->normalize($highestVersion);
+
+            if ($this->isMoreStable($version, $highestStability) ||
+                version_compare($nomalizedHighestVersion, $nomalizedVersion, '<')
+            ) {
                 $highestVersion = $version;
                 $highestStability = $this->parser->parseStability($version);
             }


### PR DESCRIPTION
### Fixed

- bug where 2.0.0 was higher than v2.8.0 is now fixed by normalising versions before comparing

--
fixes #25