### PR TITLE
Fix Phar issue in other API endpoint as well

### DIFF
--- a/app/Semver/Application.php
+++ b/app/Semver/Application.php
@@ -58,6 +58,10 @@ class Application
             $request = $request->withUri($request->getUri()->withPath('/packages/psalm/p-h-a-r'));
         }
 
+        if ($request->getUri()->getPath() == '/packages/psalm/phar/match') {
+            $request = $request->withUri($request->getUri()->withPath('/packages/psalm/p-h-a-r/match'));
+        }
+
         $response = new Response();
         $dispatcher = $this->container->get(RouteCollection::class);
 

--- a/app/Semver/Http/Controllers/PackageController.php
+++ b/app/Semver/Http/Controllers/PackageController.php
@@ -53,6 +53,9 @@ class PackageController
      */
     public function matchVersions($vendor, $package)
     {
+        // Hack to fix issue with phar in URI
+        $package = $package == 'p-h-a-r' ? 'phar' : $package;
+
         $this->configureMinimumStability();
 
         $queryParams = $this->request->getQueryParams();


### PR DESCRIPTION
### Fixed

- The app was crashing on the word `phar` in the URI

---

For some reason, league/route crashes when you use the term `phar` in a URI.  In this dirty hack, I replace it before it gets to the router. 

solves #57 