### PR TITLE
Static analysis improvements

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -10,7 +10,7 @@ class Kernel extends ConsoleKernel
     /**
      * The Artisan commands provided by your application.
      *
-     * @var array
+     * @var array<int, class-string>
      */
     protected $commands = [
         //

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,7 +10,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array
+     * @var array<int, class-string<\Throwable>>
      */
     protected $dontReport = [
         //
@@ -19,7 +19,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $dontFlash = [
         'password',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -11,7 +11,7 @@ class Kernel extends HttpKernel
      *
      * These middleware are run during every request to your application.
      *
-     * @var array
+     * @var array<int, class-string>
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
     /**
      * The application's route middleware groups.
      *
-     * @var array
+     * @var array{web: array<int, string|class-string>, api: array<int, string|class-string>}
      */
     protected $middlewareGroups = [
         'web' => [
@@ -50,7 +50,7 @@ class Kernel extends HttpKernel
      *
      * These middleware may be assigned to groups or used individually.
      *
-     * @var array
+     * @var array<string, class-string>
      */
     protected $routeMiddleware = [
         'auth' => \App\Http\Middleware\Authenticate::class,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 parameters:
     paths:
         - app
-        - config
         - database
         - resources
         - tests
@@ -12,4 +11,3 @@ parameters:
         - app/Http/Kernel.php
         - app/Console/Kernel.php
         - app/Exceptions/Handler.php
-        - config/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,4 @@ parameters:
     level: max
     excludePaths:
         - app/Http/Middleware/*.php
-        - app/Console/Kernel.php
         - app/Exceptions/Handler.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,6 @@ parameters:
         - tests
     level: max
     excludePaths:
-        - database/factories/*.php
         - app/Http/Middleware/*.php
         - app/Http/Kernel.php
         - app/Console/Kernel.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,5 @@ parameters:
     level: max
     excludePaths:
         - app/Http/Middleware/*.php
-        - app/Http/Kernel.php
         - app/Console/Kernel.php
         - app/Exceptions/Handler.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,3 @@ parameters:
     level: max
     excludePaths:
         - app/Http/Middleware/*.php
-        - app/Exceptions/Handler.php


### PR DESCRIPTION
This PR;

- removes `config` directory from `paths` and `excludePaths` in PHPStan configuration file since it doesn't make sense to provide the same path to both `paths` and `excludePaths`,
- removes `database/factories` directory from `excludePaths` in PHPStan configuration file since it doesn't exist,
- removes `app/Console/Kernel.php`, `app/Http/Kernel.php`,  and `app/Exceptions/Handler.php` files from `excludePaths` in PHPStan configuration file and specifies value type in iterable type array.