### PR TITLE
Add Coding Standards Fixer via Laravel Pint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,37 @@ jobs:
 
       - name: ✅ Run static analysis
         run: vendor/bin/phpstan analyse
+
+  coding-standards:
+    name: Coding standards
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📤 Checkout project
+        uses: actions/checkout@v3
+
+      - name: 📩 Fetch vendor from cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: 🐘 Setup PHP
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: "8.1"
+          tools: composer
+        env:
+          update: true
+
+      - name: 📦 Install dependencies
+        run: composer install --quiet --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: ✅ Run Laravel Pint
+        run: vendor/bin/pint
+
+      - name: 📥 Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Fix coding standards issues

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,7 +34,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
-        $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__ . '/Commands');
 
         require base_path('routes/console.php');
     }

--- a/app/Http/Livewire/SemverChecker.php
+++ b/app/Http/Livewire/SemverChecker.php
@@ -58,11 +58,11 @@ class SemverChecker extends Component
                     $url = substr((string) $version->getSource()?->getUrl(), 0, -4);
 
                     if (Str::startsWith($name, 'dev-')) {
-                        $url .= '/tree/'.substr($name, 4);
+                        $url .= '/tree/' . substr($name, 4);
                     } elseif (Str::endsWith($name, '-dev')) {
-                        $url .= '/tree/'.substr($name, 0, -4);
+                        $url .= '/tree/' . substr($name, 0, -4);
                     } else {
-                        $url .= '/releases/tag/'.$name;
+                        $url .= '/releases/tag/' . $name;
                     }
 
                     return new Version(
@@ -106,7 +106,7 @@ class SemverChecker extends Component
             return '';
         }
 
-        return '@'.$this->stability;
+        return '@' . $this->stability;
     }
 
     public function getIsValidConstraintProperty(VersionParser $versionParser): bool

--- a/app/Http/Livewire/SemverChecker.php
+++ b/app/Http/Livewire/SemverChecker.php
@@ -18,7 +18,9 @@ use UnexpectedValueException;
 class SemverChecker extends Component
 {
     public string $package = 'madewithlove/htaccess-cli';
+
     public string $constraint = 'dev-main';
+
     public string $stability = 'stable';
 
     /**
@@ -56,13 +58,11 @@ class SemverChecker extends Component
                     $url = substr((string) $version->getSource()?->getUrl(), 0, -4);
 
                     if (Str::startsWith($name, 'dev-')) {
-                        $url .= '/tree/' . substr($name, 4);
-                    }
-                    elseif (Str::endsWith($name, '-dev')) {
-                        $url .= '/tree/' . substr($name, 0, -4);
-                    }
-                    else {
-                        $url .= '/releases/tag/' . $name;
+                        $url .= '/tree/'.substr($name, 4);
+                    } elseif (Str::endsWith($name, '-dev')) {
+                        $url .= '/tree/'.substr($name, 0, -4);
+                    } else {
+                        $url .= '/releases/tag/'.$name;
                     }
 
                     return new Version(
@@ -106,7 +106,7 @@ class SemverChecker extends Component
             return '';
         }
 
-        return '@' . $this->stability;
+        return '@'.$this->stability;
     }
 
     public function getIsValidConstraintProperty(VersionParser $versionParser): bool

--- a/app/Packagist/ApiClient.php
+++ b/app/Packagist/ApiClient.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Packagist;
 
@@ -11,7 +13,8 @@ final class ApiClient implements Client
 {
     public function __construct(
         private BaseClient $client
-    ) {}
+    ) {
+    }
 
     public function getPackage(string $packageName): ?Package
     {
@@ -20,6 +23,7 @@ final class ApiClient implements Client
             if (is_array($result)) {
                 return $result[0];
             }
+
             return $result;
         } catch (Throwable) {
             return null;
@@ -32,7 +36,7 @@ final class ApiClient implements Client
             /** @var Result[] $results */
             $results = $this->client->search($name, [], 2);
 
-            return array_filter($results, fn(Result $result) => !empty($result->getRepository()));
+            return array_filter($results, fn (Result $result) => ! empty($result->getRepository()));
         } catch (Throwable) {
             return [];
         }

--- a/app/Packagist/CachedApiClient.php
+++ b/app/Packagist/CachedApiClient.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Packagist;
 
@@ -9,12 +11,13 @@ final class CachedApiClient implements Client
 {
     public function __construct(
         private ApiClient $client
-    ) {}
+    ) {
+    }
 
     public function getPackage(string $packageName): ?Package
     {
         /** @phpstan-ignore-next-line */
-        return Cache::remember('package-' . $packageName, 60 * 60, function () use ($packageName): ?Package {
+        return Cache::remember('package-'.$packageName, 60 * 60, function () use ($packageName): ?Package {
             return $this->client->getPackage($packageName);
         });
     }
@@ -22,7 +25,7 @@ final class CachedApiClient implements Client
     public function search(string $name): array
     {
         /** @phpstan-ignore-next-line */
-        return Cache::remember('search-' . $name, 60 * 60, function () use ($name): array {
+        return Cache::remember('search-'.$name, 60 * 60, function () use ($name): array {
             return $this->client->search($name);
         });
     }

--- a/app/Packagist/CachedApiClient.php
+++ b/app/Packagist/CachedApiClient.php
@@ -17,7 +17,7 @@ final class CachedApiClient implements Client
     public function getPackage(string $packageName): ?Package
     {
         /** @phpstan-ignore-next-line */
-        return Cache::remember('package-'.$packageName, 60 * 60, function () use ($packageName): ?Package {
+        return Cache::remember('package-' . $packageName, 60 * 60, function () use ($packageName): ?Package {
             return $this->client->getPackage($packageName);
         });
     }
@@ -25,7 +25,7 @@ final class CachedApiClient implements Client
     public function search(string $name): array
     {
         /** @phpstan-ignore-next-line */
-        return Cache::remember('search-'.$name, 60 * 60, function () use ($name): array {
+        return Cache::remember('search-' . $name, 60 * 60, function () use ($name): array {
             return $this->client->search($name);
         });
     }

--- a/app/Packagist/Client.php
+++ b/app/Packagist/Client.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Packagist;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,8 @@ namespace App\Providers;
 
 use App\Packagist\CachedApiClient;
 use App\Packagist\Client;
-use App\VirtualPackages\VirtualPackageFactory;
 use App\VirtualPackages\VirtualPackageEnrichingApiClient;
+use App\VirtualPackages\VirtualPackageFactory;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -26,7 +26,7 @@ class AppServiceProvider extends ServiceProvider
                 return new VirtualPackageEnrichingApiClient(
                     $cachedClient,
                     [
-                        VirtualPackageFactory::php()
+                        VirtualPackageFactory::php(),
                     ]
                 );
             }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,10 +2,7 @@
 
 namespace App\Providers;
 
-use Illuminate\Auth\Events\Registered;
-use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
-use Illuminate\Support\Facades\Event;
 
 class EventServiceProvider extends ServiceProvider
 {

--- a/app/Version/Matcher.php
+++ b/app/Version/Matcher.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Version;
 
@@ -11,7 +13,8 @@ final class Matcher
 {
     public function __construct(
         private VersionParser $versionParser
-    ) {}
+    ) {
+    }
 
     public function matches(string $version, string $constraint, string $requiredStability): bool
     {
@@ -23,11 +26,11 @@ final class Matcher
 
         $parsedVersion = new Constraint('=', $this->versionParser->normalize($version));
 
-        if (!$parsedVersion->matches($constraint)) {
+        if (! $parsedVersion->matches($constraint)) {
             return false;
         }
 
-        if (!$this->isMoreOrEquallyStable($version, $requiredStability)) {
+        if (! $this->isMoreOrEquallyStable($version, $requiredStability)) {
             return false;
         }
 

--- a/app/Version/Matcher.php
+++ b/app/Version/Matcher.php
@@ -9,15 +9,12 @@ use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\VersionParser;
 use UnexpectedValueException;
 
-
 final class Matcher
 {
-
     public function __construct(
         private VersionParser $versionParser
     ) {
     }
-
 
     public function matches(string $version, string $constraint, string $requiredStability): bool
     {
@@ -29,8 +26,7 @@ final class Matcher
 
         $parsedVersion = new Constraint('=', $this->versionParser->normalize($version));
 
-        if (! $parsedVersion->matches($constraint))
-        {
+        if (! $parsedVersion->matches($constraint)) {
             return false;
         }
 
@@ -47,5 +43,4 @@ final class Matcher
 
         return BasePackage::$stabilities[$stability] <= BasePackage::$stabilities[$requiredStability];
     }
-
 }

--- a/app/Version/Matcher.php
+++ b/app/Version/Matcher.php
@@ -9,12 +9,15 @@ use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\VersionParser;
 use UnexpectedValueException;
 
+
 final class Matcher
 {
+
     public function __construct(
         private VersionParser $versionParser
     ) {
     }
+
 
     public function matches(string $version, string $constraint, string $requiredStability): bool
     {
@@ -26,7 +29,8 @@ final class Matcher
 
         $parsedVersion = new Constraint('=', $this->versionParser->normalize($version));
 
-        if (! $parsedVersion->matches($constraint)) {
+        if (! $parsedVersion->matches($constraint))
+        {
             return false;
         }
 
@@ -43,4 +47,5 @@ final class Matcher
 
         return BasePackage::$stabilities[$stability] <= BasePackage::$stabilities[$requiredStability];
     }
+
 }

--- a/app/Version/Version.php
+++ b/app/Version/Version.php
@@ -10,5 +10,6 @@ final class Version
         public readonly string $name,
         public readonly string $url,
         public readonly bool $matches,
-    ) {}
+    ) {
+    }
 }

--- a/app/VirtualPackages/VirtualPackage.php
+++ b/app/VirtualPackages/VirtualPackage.php
@@ -9,7 +9,7 @@ use Packagist\Api\Result\Package;
 class VirtualPackage extends Package
 {
     /**
-     * @param VirtualPackageVersion[] $packageVersions
+     * @param  VirtualPackageVersion[]  $packageVersions
      */
     public function __construct(
         string $packageName,

--- a/app/VirtualPackages/VirtualPackageEnrichingApiClient.php
+++ b/app/VirtualPackages/VirtualPackageEnrichingApiClient.php
@@ -10,12 +10,13 @@ use Packagist\Api\Result\Package;
 class VirtualPackageEnrichingApiClient implements Client
 {
     /**
-     * @param VirtualPackage[] $virtualPackages
+     * @param  VirtualPackage[]  $virtualPackages
      */
     public function __construct(
         private Client $client,
         private array $virtualPackages,
-    ) {}
+    ) {
+    }
 
     public function getPackage(string $packageName): ?Package
     {

--- a/app/VirtualPackages/VirtualPackageFactory.php
+++ b/app/VirtualPackages/VirtualPackageFactory.php
@@ -6,7 +6,8 @@ namespace App\VirtualPackages;
 
 class VirtualPackageFactory
 {
-    public static function php(): VirtualPackage {
+    public static function php(): VirtualPackage
+    {
         return new VirtualPackage(
             'php',
             [

--- a/app/VirtualPackages/VirtualPackageVersion.php
+++ b/app/VirtualPackages/VirtualPackageVersion.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\VirtualPackages;
 
-use Packagist\Api\Result\Package\Source;
 use Packagist\Api\Result\Package\Version;
 
 class VirtualPackageVersion extends Version

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,14 @@
         "livewire/livewire": "^2.10"
     },
     "require-dev": {
-        "spatie/laravel-ignition": "^1.0",
         "fakerphp/faker": "^1.16",
+        "laravel/pint": "^1.1",
         "laravel/sail": "^1.10",
         "mockery/mockery": "^1.4",
         "nunomaduro/collision": "^6.1",
         "nunomaduro/larastan": "^2.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "spatie/laravel-ignition": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a7de8d32b0693023f524bd053dc9f0b",
+    "content-hash": "18d038ba551ab8ca45f439a94bb79a44",
     "packages": [
         {
             "name": "brick/math",
@@ -6736,6 +6736,72 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "laravel/pint",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pint.git",
+                "reference": "118a55fc3a870f20ae111b7439f18bd20298d388"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/118a55fc3a870f20ae111b7439f18bd20298d388",
+                "reference": "118a55fc3a870f20ae111b7439f18bd20298d388",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-tokenizer": "*",
+                "ext-xml": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.9.5",
+                "illuminate/view": "^9.22.1",
+                "laravel-zero/framework": "^9.1.2",
+                "mockery/mockery": "^1.5.0",
+                "nunomaduro/larastan": "^2.1.12",
+                "nunomaduro/termwind": "^1.13.0",
+                "pestphp/pest": "^1.21.3"
+            },
+            "bin": [
+                "builds/pint"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-4": {
+                    "App\\": "app/",
+                    "Database\\Seeders\\": "database/seeders/",
+                    "Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "An opinionated code formatter for PHP.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "format",
+                "formatter",
+                "lint",
+                "linter",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pint/issues",
+                "source": "https://github.com/laravel/pint"
+            },
+            "time": "2022-08-02T15:02:55+00:00"
         },
         {
             "name": "laravel/sail",

--- a/config/cache.php
+++ b/config/cache.php
@@ -101,6 +101,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_cache'),
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache'),
 
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -123,7 +123,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_'),
         ],
 
         'default' => [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -38,7 +38,7 @@ return [
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
-            'url' => env('APP_URL').'/storage',
+            'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
         ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -69,7 +69,7 @@ return [
             'handler_with' => [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
-                'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
+                'connectionString' => 'tls://' . env('PAPERTRAIL_URL') . ':' . env('PAPERTRAIL_PORT'),
             ],
         ],
 

--- a/config/session.php
+++ b/config/session.php
@@ -128,7 +128,7 @@ return [
 
     'cookie' => env(
         'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
+        Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
     ),
 
     /*

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,8 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "concat_space": {
+            "spacing": "one"
+        }
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -16,8 +16,8 @@ define('LARAVEL_START', microtime(true));
 |
 */
 
-if (file_exists(__DIR__.'/../storage/framework/maintenance.php')) {
-    require __DIR__.'/../storage/framework/maintenance.php';
+if (file_exists(__DIR__ . '/../storage/framework/maintenance.php')) {
+    require __DIR__ . '/../storage/framework/maintenance.php';
 }
 
 /*
@@ -31,7 +31,7 @@ if (file_exists(__DIR__.'/../storage/framework/maintenance.php')) {
 |
 */
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 /*
 |--------------------------------------------------------------------------
@@ -44,7 +44,7 @@ require __DIR__.'/../vendor/autoload.php';
 |
 */
 
-$app = require_once __DIR__.'/../bootstrap/app.php';
+$app = require_once __DIR__ . '/../bootstrap/app.php';
 
 $kernel = $app->make(Kernel::class);
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -13,7 +13,7 @@ trait CreatesApplication
      */
     public function createApplication()
     {
-        $app = require __DIR__.'/../bootstrap/app.php';
+        $app = require __DIR__ . '/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
 

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Feature;
 

--- a/tests/Unit/Version/MatcherTest.php
+++ b/tests/Unit/Version/MatcherTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\Unit\Version;
 


### PR DESCRIPTION
This PR adds coding standards fixer to the project via [Laravel Pint](https://github.com/laravel/pint) that is built on top of [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer). By default, Pint uses the `laravel` preset which is the opinionated coding style of Laravel ([see rules](https://github.com/laravel/pint/blob/main/resources/presets/laravel.php)).

I don’t know exactly what rules you prefer but the `laravel` preset may be a good starting point to keep coding style consistent IMO. Let me know if you want me enable/disable any rules in the preset.

Also, I added a GitHub workflow that fixes code style issues and commits changes automatically. If you prefer `--dry-run` without actually modifying the files in GitHub workflow, I'm happy to change it like so.