### PR TITLE
🤖 Use auto-injected GITHUB_TOKEN

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -13,4 +13,4 @@ jobs:
         run: gh pr merge --merge --auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `DEPENDABOT_AUTO_MERGE_PERSONAL_ACCESS_TOKEN` with the auto-injected `GITHUB_TOKEN` in the dependabot automerge workflow
- The `GITHUB_TOKEN` is automatically available in every workflow run, removing the need to manage a separate secret